### PR TITLE
fix for release 9.0

### DIFF
--- a/source/computational_domain.cc
+++ b/source/computational_domain.cc
@@ -259,7 +259,7 @@ void ComputationalDomain<dim>::read_domain()
   // manifold = new SphericalManifold<dim-1, dim>;
 
   GridTools::copy_material_to_manifold_id(tria);
-  
+
   if (input_grid_name == "../grids/coarse_sphere" || input_grid_name == "../grids/coarse_sphere_double_nodes" || input_grid_name == "../grids/circle" )
     {
       manifold = new SphericalManifold<dim-1, dim>;

--- a/source/computational_domain.cc
+++ b/source/computational_domain.cc
@@ -258,6 +258,8 @@ void ComputationalDomain<dim>::read_domain()
   //
   // manifold = new SphericalManifold<dim-1, dim>;
 
+  GridTools::copy_material_to_manifold_id(tria);
+  
   if (input_grid_name == "../grids/coarse_sphere" || input_grid_name == "../grids/coarse_sphere_double_nodes" || input_grid_name == "../grids/circle" )
     {
       manifold = new SphericalManifold<dim-1, dim>;


### PR DESCRIPTION
Without the fix we get 

<img width="608" alt="screen shot 2018-05-15 at 15 47 56" src="https://user-images.githubusercontent.com/8708485/40060633-5fb9672c-5857-11e8-9876-4e340ed47678.png">

with the fix we go back to normal

<img width="602" alt="screen shot 2018-05-15 at 15 48 04" src="https://user-images.githubusercontent.com/8708485/40060639-6320e994-5857-11e8-8e72-5d53a06bfd38.png">

it seems to be something related to how read_ucd manage the material_id <-> manifold_id